### PR TITLE
Import/Export Sync

### DIFF
--- a/code/LocationAdmin.php
+++ b/code/LocationAdmin.php
@@ -2,15 +2,14 @@
 
 class LocationAdmin extends ModelAdmin
 {
-
     private static $managed_models = array(
         'Location',
-        'LocationCategory'
+        'LocationCategory',
     );
 
     private static $model_importers = array(
         'Location' => 'LocationCsvBulkLoader',
-        'LocationCategory' => 'CsvBulkLoader'
+        'LocationCategory' => 'CsvBulkLoader',
     );
 
     private static $menu_title = 'Locator';
@@ -18,20 +17,26 @@ class LocationAdmin extends ModelAdmin
 
     public function getExportFields()
     {
-        return array(
-            'Title' => 'Name',
-            'Address' => 'Address',
-            'Suburb' => 'City',
-            'State' => 'State',
-            'Postcode' => 'Postal Code',
-            'Country' => 'Country',
-            'Website' => 'Website',
-            'Phone' => 'Phone',
-            'Fax' => 'Fax',
-            'EmailAddress' => 'Email Address',
-            'ShowInLocator' => 'Show',
-            'Lat' => 'Lat',
-            'Lng' => 'Lng'
-        );
+        if ($this->modelClass == 'Location') {
+            return array(
+                'Title' => 'Name',
+                'Address' => 'Address',
+                'Suburb' => 'City',
+                'State' => 'State',
+                'Postcode' => 'Postcode',
+                'Country' => 'Country',
+                'Website' => 'Website',
+                'Phone' => 'Phone',
+                'Fax' => 'Fax',
+                'EmailAddress' => 'EmailAddress',
+                'Category.Name' => 'Category',
+                'ShowInLocator' => 'ShowInLocator',
+                'Featured' => 'Featured',
+                'Lat' => 'Lat',
+                'Lng' => 'Lng',
+            );
+        }
+
+        return parent::getExportFields();
     }
 }

--- a/code/LocationCsvBulkLoader.php
+++ b/code/LocationCsvBulkLoader.php
@@ -4,30 +4,27 @@ class LocationCsvBulkLoader extends CsvBulkLoader
 {
     public $columnMap = array(
         'Name' => 'Title',
-        //'Address' => 'Address',
         'City' => 'Suburb',
-        //'State' => 'State',
-        'Zip' => 'Postcode',
         'Category' => 'Category.Name',
-        'Email' => 'EmailAddress'
-    );
-
-    public $duplicateChecks = array(
-        'Address' => 'Address',
-        //'Website' => 'Website'
     );
 
     public $relationCallbacks = array(
-        'Category.Name' => array(
-            'relationname' => 'Category',
-            'callback' => 'getCatByName'
-        )
+       'Category.Name' => array(
+           'relationname' => 'Category',
+           'callback' => 'getCategoryByName',
+        ),
     );
 
-    public static function getCatByName(&$obj, $val, $record)
+    public static function getCategoryByName(&$obj, $val, $record)
     {
         $val = Convert::raw2sql($val);
-        return LocationCategory::get()->filter('Name', $val)->First();
-        //);
+        $category = LocationCategory::get()->filter(array('Name' => $val))->First();
+        if (!$category) {
+            $category = LocationCategory::create();
+            $category->Name = $val;
+            $category->write();
+        }
+
+        return $category;
     }
 }


### PR DESCRIPTION
Matched fields in LocationAdmin::getExportFields() with LocationCsvBulkLoader.

Can now export easily from one Locator installation to another without data loss or reformatting column headers in CSV

fixes #59