### PR TITLE
Locator - allow filter by LocationCategory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,6 @@ matrix:
         env: DB=SQLITE
       - php: hhvm
         env: DB=MYSQL
-      - php: 5.5
-        env: DB=MYSQL
   allow_failures:
       - php: 7.0
 

--- a/code/LocationCategory.php
+++ b/code/LocationCategory.php
@@ -10,8 +10,12 @@ class LocationCategory extends DataObject
         'Locations' => 'Location',
     );
 
-    private static $singular_name = 'Category';
-    private static $plural_name = 'Categories';
+    private static $belogs_many_many = array(
+        'Locators' => 'Locator'
+    );
+
+    private static $singular_name = "Category";
+    Private static $plural_name = "Categories";
 
     private static $default_sort = 'Name';
 }

--- a/code/Locator.php
+++ b/code/Locator.php
@@ -207,7 +207,7 @@ class Locator_Controller extends Page_Controller
 
         $locatorCategories = Locator::getPageCategories($this->ID);
 
-        if (LocationCategory::get()->Count() > 0 && $locatorCategories && $locatorCategories->Count() < 1) {
+        if (LocationCategory::get()->Count() > 0 && $locatorCategories && $locatorCategories->Count() != 1) {
             $categories = LocationCategory::get();
 
             if ($categories->count() > 0) {

--- a/code/Locator.php
+++ b/code/Locator.php
@@ -8,26 +8,21 @@ class Locator extends Page
         'Unit' => 'Enum("m,km","m")',
     );
 
+    private static $many_many = array(
+        'Categories' => 'LocationCategory',
+    );
+
     private static $defaults = array(
         'AutoGeocode' => true,
     );
 
     private static $singular_name = 'Locator';
     private static $plural_name = 'Locators';
-    private static $description = 'Show locations on a map';
+    private static $description = 'Find locations on a map';
 
     public function getCMSFields()
     {
         $fields = parent::getCMSFields();
-
-        // Locations Grid Field
-        $config = GridFieldConfig_RecordEditor::create();
-        $locations = Location::get();
-        $fields->addFieldToTab('Root.Locations', GridField::create('Locations', 'Locations', $locations, $config));
-
-        // Location categories
-        $config = GridFieldConfig_RecordEditor::create();
-        $fields->addFieldToTab('Root.Categories', GridField::create('Categories', 'Categories', LocationCategory::get(), $config));
 
         // Settings
         $fields->addFieldsToTab('Root.Settings', array(
@@ -38,19 +33,35 @@ class Locator extends Page
             CheckboxField::create('ModalWindow', 'Modal Window - Show Map results in a modal window'),
         ));
 
+        // Filter categories
+        $config = GridFieldConfig_RelationEditor::create();
+        if (class_exists('GridFieldAddExistingSearchButton')) {
+            $config->removeComponentsByType('GridFieldAddExistingAutocompleter');
+            $config->addComponent(new GridFieldAddExistingSearchButton());
+        }
+        $categories = $this->Categories();
+        $categoriesField = GridField::create('Categories', 'Categories', $categories, $config)
+            ->setDescription('only show locations from the selected category');
+
+            // Filter
+            $fields->addFieldsToTab('Root.Filter', array(
+                HeaderField::create('CategoryOptionsHeader', 'Location Filtering', 3),
+                $categoriesField,
+            ));
+
         $this->extend('updateCMSFields', $fields);
 
         return $fields;
     }
 
-    public static function getLocations($filter = array(), $exclude = array())
+    public static function getLocations($filter = array(), $exclude = array(), $filterAny = array())
     {
         $filter['ShowInLocator'] = true;
+        $exclude['Lat'] = 0;
 
-        return Location::get()
-            ->exclude($exclude)
-            ->exclude('Lat', 0)
-            ->filter($filter);
+        $Locations = Location::get()->exclude($exclude)->filter($filter)->filterAny($filterAny);
+
+        return $Locations;
     }
 
     public function getAreLocations()
@@ -61,6 +72,17 @@ class Locator extends Page
     public function getAllCategories()
     {
         return LocationCategory::get();
+    }
+
+    public static function getPageCategories($id = null)
+    {
+        if ($id) {
+            if ($locator = Locator::get()->byID($id)) {
+                return $locator->Categories();
+            }
+            return false;
+        }
+        return false;
     }
 }
 
@@ -151,7 +173,18 @@ class Locator_Controller extends Page_Controller
     public function xml(SS_HTTPRequest $request)
     {
         $filter = array();
-        $Locations = Locator::getLocations($filter);
+        $exclude = array();
+        $filterAny = array();
+
+        //if a category filter selected
+        if ($this->Categories()->exists()) {
+            $categories = $this->Categories();
+            foreach ($categories as $category) {
+                $filterAny['CategoryID'] = $category->ID;
+            }
+        }
+
+        $Locations = Locator::getLocations($filter, $exclude, $filterAny);
 
         return $this->customise(array(
             'Locations' => $Locations,
@@ -172,14 +205,10 @@ class Locator_Controller extends Page_Controller
         );
         $address->setAttribute('placeholder', 'address or zip code');
 
-        if (LocationCategory::get()->Count() > 0) {
-            $filter = array();
-            $locals = Locator::getLocations($filter, $exclude = array('CategoryID' => 0));
-            $categories = ArrayList::create();
+        $locatorCategories = Locator::getPageCategories($this->ID);
 
-            foreach ($locals as $local) {
-                $categories->add($local->Category());
-            }
+        if (LocationCategory::get()->Count() > 0 && $locatorCategories && $locatorCategories->Count() < 1) {
+            $categories = LocationCategory::get();
 
             if ($categories->count() > 0) {
                 $fields->push(

--- a/tests/LocatorTest.php
+++ b/tests/LocatorTest.php
@@ -11,18 +11,8 @@ class LocatorTest extends Locator_Test
 
     public function testGetLocations()
     {
-        $object = $this->objFromFixture('Location', 'dynamic');
-        $object->write();
-
-        $object2 = $this->objFromFixture('Location', 'silverstripe');
-        $object2->write();
-
-        $object3 = $this->objFromFixture('Location', '3sheeps');
-        $object3->write();
-
         $locator = singleton('Locator');
         $count = Location::get()->filter('ShowInLocator', 1)->exclude('Lat', 0)->Count();
-
         $this->assertEquals($locator->getLocations()->Count(), $count);
     }
 
@@ -35,16 +25,21 @@ class LocatorTest extends Locator_Test
     public function testGetAllCategories()
     {
         $locator = singleton('Locator');
-
-        $object = $this->objFromFixture('LocationCategory', 'service');
-        $object->write();
-
-        $object2 = $this->objFromFixture('LocationCategory', 'manufacturing');
-        $object2->write();
-
         $count = LocationCategory::get();
-
         $this->assertEquals($locator->getAllCategories(), $count);
+    }
+
+    public function testGetPageCategories()
+    {
+        $locator = Locator::create();
+        $this->assertFalse($locator->getPageCategories());
+
+        $this->assertFalse($locator->getPageCategories(500));
+
+        $locator->write();
+        $category = $this->objFromFixture('LocationCategory', 'service');
+        $locator->Categories()->add($category);
+        $this->assertEquals($locator->getPageCategories($locator->ID), $locator->Categories());
     }
 
     public function testInit()
@@ -57,8 +52,19 @@ class LocatorTest extends Locator_Test
 
     public function testLocationSearch()
     {
-        $object = Locator_Controller::create();
+        $locator = $this->objFromFixture('Locator', 'locator1');
+        $object = Locator_Controller::create($locator);
         $form = $object->LocationSearch();
         $this->assertTrue(is_a($form, 'Form'));
+        
+        $category = $this->objFromFixture('LocationCategory', 'service');
+        $category2 = $this->objFromFixture('LocationCategory', 'manufacturing');
+        $locator->Categories()->add($category);
+        $locator->Categories()->add($category2);
+
+        $form = $object->LocationSearch();
+        $fields = $form->Fields();
+        $this->assertNotNull($fields->fieldByName('category'));
+        
     }
 }


### PR DESCRIPTION
In CMS Settings tab on Locator page, added following:

`has_one LocationCategory`

If a user selects a category, list is filtered by that category on load, and category drop down is removed from the search form.

Allows module to have multiple Locator pages in a site and show different locations on each.

fixes #57