### PR TITLE
Import - Import_ID duplicate check

### DIFF
--- a/code/bulkloader/LocationCsvBulkLoader.php
+++ b/code/bulkloader/LocationCsvBulkLoader.php
@@ -14,6 +14,14 @@ class LocationCsvBulkLoader extends CsvBulkLoader
         'City' => 'Suburb',
         'EmailAddress' => 'Email',
         'Category' => 'Category.Name',
+        'Import_ID' => 'Import_ID',
+    );
+
+    /**
+     * @var array
+     */
+    public $duplicateChecks = array(
+        'Import_ID' => 'Import_ID'
     );
 
     /**

--- a/code/objects/Location.php
+++ b/code/objects/Location.php
@@ -10,6 +10,7 @@
  * @property string $Email
  * @property string $EmailAddress
  * @property bool $ShowInLocator
+ * @property int $Import_ID
  * @property int $CategoryID
  * @method LocationCategory $Category
  */
@@ -27,6 +28,7 @@ class Location extends DataObject implements PermissionProvider
         'Email' => 'Varchar(255)',
         'EmailAddress' => 'Varchar(255)',
         'ShowInLocator' => 'Boolean',
+        'Import_ID' => 'Int',
     );
 
     /**
@@ -174,6 +176,10 @@ class Location extends DataObject implements PermissionProvider
 
         // override Suburb field name
         $fields->dataFieldByName('Suburb')->setTitle('City');
+
+        $fields->removeByName(array(
+            'Import_ID',
+        ));
 
         return $fields;
     }

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -1,18 +1,7 @@
 #SilverStripe Locator
 
-## User Guide
+##Using Locator
 
-Create a Locator page in the CMS. Enabling Auto Geocode will return the 26 nearest locations to that user's current location. If not enabled, all locations will be shown on the map.
+See [User Guide](userguide/index.md) for information on using the Locator module in the CMS.
 
-You can also filter locations by one or more categories. This is useful if you'd like to have multiple Locators in a site with different locations on each map.
-
-![screen shot](../../images/LocatorPage.png)
-
-Locations are managed under the Locations tab in the CMS via Model Admin. Simply enter the name and address of each location, and the coordinates will be generated on save.
-
-![screen shot](../../images/LocatorCMS.png)
-
-Those locations marked as `ShowInLocator` will display on the map, per your Locator page settings.
-
-![screen shot](../../images/Locator.png)
-
+See [Importing Locations](userguide/import.md) for information on importing Location and Category records.

--- a/docs/en/userguide/import.md
+++ b/docs/en/userguide/import.md
@@ -1,0 +1,5 @@
+# Importing Locations
+
+For large installations, you can import Location and Category data via the Locator Admin. Simply export as CSV to get the spreadsheet template, fill out the sheet, and import via the Locator admin.
+
+For duplication checks, to update exsiting records rather than always replace the data, create a `Import_ID` column in your spreadsheet with an auto-increment integer. For large uploads, this will allow you to skip already existing records in those cases where your initial import times/errors out.

--- a/docs/en/userguide/index.md
+++ b/docs/en/userguide/index.md
@@ -1,0 +1,16 @@
+# User Guide
+
+Create a Locator page in the CMS. Enabling Auto Geocode will return the 26 nearest locations to that user's current location. If not enabled, all locations will be shown on the map.
+
+You can also filter locations by one or more categories. This is useful if you'd like to have multiple Locators in a site with different locations on each map.
+
+![screen shot](../../../images/LocatorPage.png)
+
+Locations are managed under the Locations tab in the CMS via Model Admin. Simply enter the name and address of each location, and the coordinates will be generated on save.
+
+![screen shot](../../../images/LocatorCMS.png)
+
+Those locations marked as `ShowInLocator` will display on the map, per your Locator page settings.
+
+![screen shot](../../../images/Locator.png)
+

--- a/tests/LocationTest.php
+++ b/tests/LocationTest.php
@@ -51,6 +51,7 @@ class LocationTest extends SapphireTest
             'Category.ID' => 'Category',
             'Featured.NiceAsBoolean' => 'Featured',
             'Coords' => 'Coords',
+            'Import_ID' => 'Import_ID',
         );
         $this->assertEquals($expected, $labels);
     }


### PR DESCRIPTION
Added `Import_ID` DB field to Location. Updated `LocationCsvBulkLoader` to create a duplicate check for `Import_ID`. This will allow an optional duplicate check for large imports that may time/error out.

Updated docs to illustrate how to use `Import_ID` on import.