### PR TITLE
Fixed website urls not defaulting to external

### DIFF
--- a/src/objects/Location.php
+++ b/src/objects/Location.php
@@ -144,6 +144,18 @@ class Location extends DataObject implements PermissionProvider
     }
 
     /**
+     * @return mixed
+     */
+    public function getWebsite()
+    {
+        $website = $this->getField('Website');
+        if ($website && strpos($website, '//') === false && strpos($website, '.') >= 0) {
+            return '//' . $website;
+        }
+        return $website;
+    }
+
+    /**
      * @return bool|string
      */
     public function getCountryCode()


### PR DESCRIPTION
  - will only re-adjust if there is a '.' in the url and '//' is not