### PR TITLE
Bugfix: Fixed mistaken namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ With auto geocoding enabled in the CMS, the map will display the nearest 26 loca
 See the [docs/en](docs/en/index.md) folder.
 
 ## Maintainers
- *  [Dynamic](http://www.dynamicagency.com) (<dev@dynamicagency.com>)
+ *  [Dynamic](https://www.dynamicagency.com) (<dev@dynamicagency.com>)
  
 ## Bugtracker
 Bugs are tracked in the issues section of this repository. Before submitting an issue please read over 

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -1,7 +1,7 @@
 ---
 Name: locator
 ---
-Dynamic\Locator\Location:
+Dynamic\Locator\Model\Location:
   extensions:
     - Dynamic\SilverStripeGeocoder\DistanceDataExtension
     - Dynamic\SilverStripeGeocoder\AddressDataExtension

--- a/_config/legacy.yml
+++ b/_config/legacy.yml
@@ -3,6 +3,6 @@ name: locatorlegacy
 ---
 SilverStripe\ORM\DatabaseAdmin:
   classname_value_remapping:
-    Dynamic\Locator\Location: Dynamic\Locator\Location
+    Dynamic\Locator\Location: Dynamic\Locator\Model\Location
     Dynamic\Locator\Locator: Dynamic\Locator\Page\Locator
     Dynamic\Locator\LocationCategory: Dynamic\Locator\Model\LocationCategory

--- a/src/Model/Location.php
+++ b/src/Model/Location.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Dynamic\Locator;
+namespace Dynamic\Locator\Model;
 
 use Dynamic\Locator\Model\LocationCategory;
 use SilverStripe\Forms\GridField\GridFieldAddExistingAutocompleter;

--- a/src/Model/LocationCategory.php
+++ b/src/Model/LocationCategory.php
@@ -2,7 +2,7 @@
 
 namespace Dynamic\Locator\Model;
 
-use Dynamic\Locator\Location;
+use Dynamic\Locator\Model\Location;
 use Dynamic\Locator\Page\Locator;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\GridField\GridField;

--- a/src/Tasks/EmailAddressTask.php
+++ b/src/Tasks/EmailAddressTask.php
@@ -2,7 +2,7 @@
 
 namespace Dynamic\Locator\Tasks;
 
-use Dynamic\Locator\Location;
+use Dynamic\Locator\Model\Location;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Dev\BuildTask;

--- a/src/Tasks/LocationToPageTask.php
+++ b/src/Tasks/LocationToPageTask.php
@@ -2,7 +2,7 @@
 
 namespace Dynamic\Locator\Tasks;
 
-use Dynamic\Locator\Location;
+use Dynamic\Locator\Model\Location;
 use Dynamic\Locator\Page\LocationPage;
 use Dynamic\Locator\Page\Locator;
 use SilverStripe\Core\Injector\Injector;

--- a/src/bulkloader/LocationCsvBulkLoader.php
+++ b/src/bulkloader/LocationCsvBulkLoader.php
@@ -2,7 +2,7 @@
 
 namespace Dynamic\Locator\Bulkloader;
 
-use Dynamic\Locator\Location;
+use Dynamic\Locator\Model\Location;
 use Dynamic\Locator\Model\LocationCategory;
 use SilverStripe\Dev\CsvBulkLoader;
 use SilverStripe\Core\Convert;

--- a/tests/Model/LocationTest.php
+++ b/tests/Model/LocationTest.php
@@ -6,7 +6,7 @@ use Dynamic\Locator\Tests\TestOnly\Extension\LocationExtension;
 use Dynamic\Locator\Tests\TestOnlyModel\ExtendedLocation;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
-use Dynamic\Locator\Location;
+use Dynamic\Locator\Model\Location;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Security\Member;
 
@@ -215,7 +215,7 @@ class LocationTest extends SapphireTest
         $clone = Injector::inst()->create(ExtendedLocation::class, $map);
         $clone->ID = 0;
 
-        $this->assertEquals('http://www.dynamicagency.com', $location->getWebsiteURL());
+        $this->assertEquals('https://www.dynamicagency.com', $location->getWebsiteURL());
         $this->assertEquals('foo', $clone->getWebsiteURL());
     }
 }

--- a/tests/Model/locationfixture.yml
+++ b/tests/Model/locationfixture.yml
@@ -56,11 +56,11 @@ Dynamic\Locator\Page\Locator:
     Title: Locator
     Categories: =>Dynamic\Locator\Model\LocationCategory.service,=>Dynamic\Locator\Model\LocationCategory.technology
 
-Dynamic\Locator\Location:
+Dynamic\Locator\Model\Location:
   dynamic:
     Title: Dynamic, Inc.
     Featured: true
-    Website: "http://www.dynamicagency.com"
+    Website: "https://www.dynamicagency.com"
     Phone: 920-459-8889
     Email: dev@dy.ag
     Address: 1526 S. 12th St
@@ -72,14 +72,14 @@ Dynamic\Locator\Location:
   silverstripe:
     Title: Silverstripe
     Featured: true
-    Website: http://silverstripe.org
+    Website: https://silverstripe.org
     Phone: 555-555-5555
     Email: solutions@silverstripe.com
     Categories: =>Dynamic\Locator\Model\LocationCategory.service
   3sheeps:
     Title: 3 Sheeps Brewing
     Featured: false
-    Website: http://www.3sheepsbrewing.com
+    Website: https://www.3sheepsbrewing.com
     Phone: 555-555-5556
     ShowInLocator: false
     Address: 1327 Huron Ave

--- a/tests/Page/LocatorControllerTest.php
+++ b/tests/Page/LocatorControllerTest.php
@@ -2,7 +2,7 @@
 
 namespace Dynamic\Locator\Tests\Page;
 
-use Dynamic\Locator\Location;
+use Dynamic\Locator\Model\Location;
 use Dynamic\Locator\Model\LocationCategory;
 use Dynamic\Locator\Page\Locator;
 use Dynamic\Locator\Page\LocatorController;

--- a/tests/Page/LocatorTest.php
+++ b/tests/Page/LocatorTest.php
@@ -2,7 +2,7 @@
 
 namespace Dynamic\Locator\Tests\Page;
 
-use Dynamic\Locator\Location;
+use Dynamic\Locator\Model\Location;
 use Dynamic\Locator\Page\Locator;
 use Dynamic\Locator\Page\LocatorController;
 use SilverStripe\Core\Config\Config;

--- a/tests/Page/locatorfixture.yml
+++ b/tests/Page/locatorfixture.yml
@@ -13,11 +13,11 @@ Dynamic\Locator\Page\Locator:
     Title: Locator
     Categories: =>Dynamic\Locator\Model\LocationCategory.service,=>Dynamic\Locator\Model\LocationCategory.technology
 
-Dynamic\Locator\Location:
+Dynamic\Locator\Model\Location:
   dynamic:
     Title: Dynamic, Inc.
     Featured: true
-    Website: "http://www.dynamicagency.com"
+    Website: "https://www.dynamicagency.com"
     Phone: 920-459-8889
     Email: dev@dy.ag
     Address: 1526 S. 12th St
@@ -29,14 +29,14 @@ Dynamic\Locator\Location:
   silverstripe:
     Title: Silverstripe
     Featured: true
-    Website: http://silverstripe.org
+    Website: https://silverstripe.org
     Phone: 555-555-5555
     Email: solutions@silverstripe.com
     Categories: =>Dynamic\Locator\Model\LocationCategory.service
   3sheeps:
     Title: 3 Sheeps Brewing
     Featured: false
-    Website: http://www.3sheepsbrewing.com
+    Website: https://www.3sheepsbrewing.com
     Phone: 555-555-5556
     ShowInLocator: false
     Address: 1327 Huron Ave

--- a/tests/TestOnly/Model/ExtendedLocation.php
+++ b/tests/TestOnly/Model/ExtendedLocation.php
@@ -2,7 +2,7 @@
 
 namespace Dynamic\Locator\Tests\TestOnlyModel;
 
-use Dynamic\Locator\Location;
+use Dynamic\Locator\Model\Location;
 use Dynamic\Locator\Tests\TestOnly\Extension\LocationExtension;
 use SilverStripe\Dev\TestOnly;
 

--- a/tests/fixtures.yml
+++ b/tests/fixtures.yml
@@ -56,11 +56,11 @@ Dynamic\Locator\Page\Locator:
     Title: Locator
     Categories: =>Dynamic\Locator\Model\LocationCategory.service,=>Dynamic\Locator\Model\LocationCategory.technology
 
-Dynamic\Locator\Location:
+Dynamic\Locator\Model\Location:
   dynamic:
     Title: Dynamic, Inc.
     Featured: true
-    Website: "http://www.dynamicagency.com"
+    Website: "https://www.dynamicagency.com"
     Phone: 920-459-8889
     Email: dev@dy.ag
     Address: 1526 S. 12th St
@@ -72,14 +72,14 @@ Dynamic\Locator\Location:
   silverstripe:
     Title: Silverstripe
     Featured: true
-    Website: http://silverstripe.org
+    Website: https://silverstripe.org
     Phone: 555-555-5555
     Email: solutions@silverstripe.com
     Categories: =>Dynamic\Locator\Model\LocationCategory.service
   3sheeps:
     Title: 3 Sheeps Brewing
     Featured: false
-    Website: http://www.3sheepsbrewing.com
+    Website: https://www.3sheepsbrewing.com
     Phone: 555-555-5556
     ShowInLocator: false
     Address: 1327 Huron Ave
@@ -103,7 +103,7 @@ Dynamic\Locator\Model\Page\LocationPage:
   dynamic:
     Title: Dynamic, Inc.
     Featured: true
-    Website: "http://www.dynamicagency.com"
+    Website: "https://www.dynamicagency.com"
     Phone: 920-459-8889
     Email: dev@dy.ag
     Address: 1526 S. 12th St
@@ -116,7 +116,7 @@ Dynamic\Locator\Model\Page\LocationPage:
   silverstripe:
     Title: Silverstripe
     Featured: true
-    Website: http://silverstripe.org
+    Website: https://silverstripe.org
     Phone: 555-555-5555
     Email: solutions@silverstripe.com
     Categories: =>Dynamic\Locator\Model\LocationCategory.service
@@ -124,7 +124,7 @@ Dynamic\Locator\Model\Page\LocationPage:
   3sheeps:
     Title: 3 Sheeps Brewing
     Featured: false
-    Website: http://www.3sheepsbrewing.com
+    Website: https://www.3sheepsbrewing.com
     Phone: 555-555-5556
     ShowInLocator: false
     Address: 1327 Huron Ave

--- a/tests/form/LocatorFormTest.php
+++ b/tests/form/LocatorFormTest.php
@@ -2,7 +2,7 @@
 
 namespace Dynamic\Locator\Tests\Form;
 
-use Dynamic\Locator\Location;
+use Dynamic\Locator\Model\Location;
 use Dynamic\Locator\Page\Locator;
 use Dynamic\Locator\Page\LocatorController;
 use Dynamic\Locator\Form\LocatorForm;

--- a/tests/form/locatorformfixture.yml
+++ b/tests/form/locatorformfixture.yml
@@ -13,11 +13,11 @@ Dynamic\Locator\Page\Locator:
     Title: Locator
     Categories: =>Dynamic\Locator\Model\LocationCategory.service,=>Dynamic\Locator\Model\LocationCategory.technology
 
-Dynamic\Locator\Location:
+Dynamic\Locator\Model\Location:
   dynamic:
     Title: Dynamic, Inc.
     Featured: true
-    Website: "http://www.dynamicagency.com"
+    Website: "https://www.dynamicagency.com"
     Phone: 920-459-8889
     Email: dev@dy.ag
     Address: 1526 S. 12th St
@@ -29,14 +29,14 @@ Dynamic\Locator\Location:
   silverstripe:
     Title: Silverstripe
     Featured: true
-    Website: http://silverstripe.org
+    Website: https://silverstripe.org
     Phone: 555-555-5555
     Email: solutions@silverstripe.com
     Categories: =>Dynamic\Locator\Model\LocationCategory.service
   3sheeps:
     Title: 3 Sheeps Brewing
     Featured: false
-    Website: http://www.3sheepsbrewing.com
+    Website: https://www.3sheepsbrewing.com
     Phone: 555-555-5556
     ShowInLocator: false
     Address: 1327 Huron Ave


### PR DESCRIPTION
Originally, `Location` and `LocationCategory` were located under `Dynamic\Locator\`

At `4.0.0` they were moved to `Dynamic\Locator\Model\`; however `Location` didn't get completely migrated over, causing fatal errors when running related `/dev/tasks`.

This pull request completes the migration.

PS: ...and also updates some inconsequential http links to https