### PR TITLE
Upgrade v3 to current geocoder compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "silverstripe/recipe-cms": "^4.0",
         "silverstripe/vendor-plugin": "^1.0",
         "muskie9/data-to-arraylist": "^2.0",
-        "dynamic/silverstripe-geocoder": "^1.0",
+        "dynamic/silverstripe-geocoder": "^2.0",
         "symbiote/silverstripe-gridfieldextensions": "^3.0",
         "colymba/gridfield-bulk-editing-tools": "^3.0"
     },

--- a/src/pages/LocatorController.php
+++ b/src/pages/LocatorController.php
@@ -315,8 +315,8 @@ class LocatorController extends \PageController
         if (class_exists(GoogleGeocoder::class)) {
             $geocoder = new GoogleGeocoder($this->request->getVar($addressVar));
             $response = $geocoder->getResult();
-            $lat = $response->getLatitude();
-            $lng = $response->getLongitude();
+            $lat = $response->getCoordinates()->getLatitude();
+            $lng = $response->getCoordinates()->getLongitude();
 
             return new ArrayData([
                 "Lat" => $lat,


### PR DESCRIPTION
Just noticed you're working on this at the same time I am - starting a pull request.

FYI - due to several other packages requiring `dynamic/silverstripe-geocoder:^1.0`, you may need to run the following until it's safe to upgrade all the others (e.g. `core-tools`, `silverstripe-elemental-customer-service`, etc):

```
ddev composer require dynamic/silverstripe-geocoder:"2.0.4 as 1.3.1"
```